### PR TITLE
Complete 'View Accomplished Payments' feature and improve flow

### DIFF
--- a/api/reminder.go
+++ b/api/reminder.go
@@ -27,6 +27,19 @@ func SaveReminder(userID string, amount float64, accountName string, gcashNumber
 	return result.Error
 }
 
+func GetReminderByID(reminderID string) (*models.RemindersLog, error) {
+	var reminder models.RemindersLog
+	reminderIDUint, err := strconv.ParseUint(reminderID, 10, 32) // Assuming ID is uint
+	if err != nil {
+		return nil, fmt.Errorf("error converting reminderID to uint: %w", err)
+	}
+	result := database.DB.First(&reminder, uint(reminderIDUint)) // Use uint for GORM
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	return &reminder, nil
+}
+
 func GetReminders(userID string, status string) ([]models.RemindersLog, error) {
 	var reminders []models.RemindersLog
 

--- a/utils/generate_report.go
+++ b/utils/generate_report.go
@@ -37,12 +37,7 @@ func GetRemindersReport(reminders []models.RemindersLog) []templates.Template {
 	var reportElements []templates.Template
 
 	if len(reminders) == 0 {
-		element := templates.Template{
-			Title:    "Reminders Report",
-			Subtitle: "No pending reminders found.",
-		}
-		reportElements = append(reportElements, element)
-		return reportElements
+		return reportElements // or return []templates.Template{}
 	}
 
 	for _, reminder := range reminders {
@@ -63,6 +58,15 @@ func GetRemindersReport(reminders []models.RemindersLog) []templates.Template {
 				Type:    "postback",
 				Title:   "Mark as Paid",
 				Payload: "MARK_AS_PAID_" + fmt.Sprint(reminder.ID),
+			})
+		} else if reminder.Status == "completed" || reminder.Status == "paid" {
+			title = fmt.Sprintf("Accomplished: Payment to %s", reminder.Recipient)
+			// Subtitle remains the same
+			buttons = []templates.Button{} // Initialize as empty slice
+			buttons = append(buttons, templates.Button{
+				Type:    "postback",
+				Title:   "View Details",
+				Payload: fmt.Sprintf("VIEW_ACCOMPLISHED_DETAIL_%d", reminder.ID),
 			})
 		}
 


### PR DESCRIPTION
This commit implements the following enhancements:

- **Completed 'View Accomplished Payments' Button Feature:**
    - Modified `utils/generate_report.go` (`GetRemindersReport`) to add a "View Details" button to each accomplished payment template. The title of these templates now clearly indicates "Accomplished: Payment to [Recipient]".
    - The "View Details" button uses a payload `VIEW_ACCOMPLISHED_DETAIL_<REMINDER_ID>`.

- **New Command Handler for Details:**
    - Added a handler in `services/main_bot.go` for `VIEW_ACCOMPLISHED_DETAIL_<REMINDER_ID>`.
    - This handler fetches the specific reminder using a new function `api.GetReminderByID(reminderID)` (added in `api/reminder.go`) and sends its details as a text message to you.

- **Improved Flow for Accomplished Payments:**
    - Modified `services/main_bot.go` to use `utils.SendTemplateMessage` in the `VIEW_ACCOMPLISHED_PAYMENTS_MESSAGE` case. This displays multiple accomplished payments in a single carousel message instead of separate messages.

- **Refined Instructions/Text & Edge Case Handling:**
    - Reviewed and ensured clarity of text for titles, subtitles, and buttons related to accomplished payments.
    - Corrected the logic for displaying a message when no accomplished payments are found. `GetRemindersReport` now returns an empty slice if no reminders are provided, and `services/main_bot.go` checks the reminder count before attempting to generate a report, ensuring the correct "You don't have any accomplished payments yet." message is displayed.